### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html class="" lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -8,6 +8,12 @@
     <title>Simon Lundberg</title>
   </head>
   <body>
+    <div id="topbar">
+      <label class="switch">
+        <input id="theme-toggle" type="checkbox" title="Toggle dark mode">
+        <span class="slider round"></span>
+      </label>
+    </div>
     <main>
       <div id="name-header">Simon Lundberg</div>
       <div class="link-container">
@@ -37,4 +43,6 @@
       <div>Made by Simon Lundberg</div>
     </main>
   </body>
+
+  <script src="scripts/toggleTheme.js"></script>
 </html>

--- a/scripts/toggleTheme.js
+++ b/scripts/toggleTheme.js
@@ -1,0 +1,38 @@
+(() => {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) return; // nothing to do if toggle isn't present
+
+  const THEME_KEY = 'theme';
+  // Set this to true to default to light, false to default to dark
+  const DEFAULT_IS_LIGHT = false;
+
+  const root = document.documentElement;
+
+  function setTheme(isLight) {
+    root.classList.toggle('light', isLight);
+    // update the checkbox to reflect current state (checked = light)
+    toggle.checked = isLight;
+    // persist choice
+    try {
+      localStorage.setItem(THEME_KEY, isLight ? 'light' : 'dark');
+    } catch (e) {
+      // ignore storage errors
+    }
+  }
+
+  // Initialize from localStorage (if present) otherwise use default
+  let initialIsLight = DEFAULT_IS_LIGHT;
+  try {
+    const saved = localStorage.getItem(THEME_KEY);
+    if (saved === 'dark' || saved === 'light') {
+      initialIsLight = saved === 'light';
+    }
+  } catch (e) {
+    // ignore
+  }
+
+  setTheme(initialIsLight);
+
+  // When the checkbox changes, apply and persist the new theme (checked = light)
+  toggle.addEventListener('change', () => setTheme(toggle.checked));
+})();

--- a/styles.css
+++ b/styles.css
@@ -2,8 +2,24 @@
   --bg: oklch(20% 0 264);
   --surface: oklch(25% 0 264);
   --surface-hover: oklch(35% 0 264);
+  --surface-secondary: oklch(45% 0 264);
   --text-primary: oklch(96% 0 264);
   --text-secondary: oklch(56% 0 264);
+  --shadow-s: inset 0 1px 2px #ffffff30, /* top highlight */
+    0 1px 2px #00000030, /* dark shadow */
+    0 2px 4px #00000015; /* soft shadow */
+  --shadow-l: inset 0 1px 2px #ffffff70, /* top highlight */
+    0 4px 6px #00000030, /* dark shadow */
+    0 6px 10px #00000015; /* soft shadow */
+}
+
+.light {
+  --bg: oklch(85% 0 264);
+  --surface: oklch(90% 0 264);
+  --surface-hover: oklch(85% 0 264);
+  --surface-secondary: oklch(45% 0 264);
+  --text-primary: oklch(10% 0 264);
+  --text-secondary: oklch(36% 0 264);
   --shadow-s: inset 0 1px 2px #ffffff30, /* top highlight */
     0 1px 2px #00000030, /* dark shadow */
     0 2px 4px #00000015; /* soft shadow */
@@ -56,6 +72,78 @@ main {
   align-items: center;
   gap: 1rem;
   flex: 1;
+}
+
+#topbar {
+  background-color: var(--bg);
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  padding: 5px;
+  /* height: 40px; */
+  display: flex;
+  align-items: center;
+}
+
+/* Slider Button */
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+}
+/* Hide default HTML checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--surface);
+  -webkit-transition: .4s;
+  transition: .4s;
+  box-shadow: var(--shadow-s);
+}
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: var(--surface-secondary);
+  -webkit-transition: .4s;
+  transition: .4s;
+  box-shadow: var(--shadow-s);
+}
+input:checked + .slider {
+  /* background-color: #2196F3; */
+}
+input:focus + .slider {
+  /* box-shadow: none; */
+}
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+  /* background-color: var(--bg); */
+}
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+.slider.round:before {
+  border-radius: 50%;
 }
 
 #name-header {
@@ -111,7 +199,7 @@ main {
   padding: 1rem;
   border-radius: 1rem;
   /* border: 1px solid rgb(38, 36, 61); */
-  transition: all 0.3s ease-out;
+  /* transition: all 0.3s ease-out; */
   cursor: pointer;
   box-shadow: var(--shadow-s);
 }
@@ -127,7 +215,7 @@ main {
   flex-direction: column;
   gap: 0.3rem;
   /* border: 1px solid rgb(38, 36, 61); */
-  transition: all 0.3s ease-out;
+  /* transition: all 0.3s ease-out; */
   cursor: pointer;
   box-shadow: var(--shadow-s);
 }


### PR DESCRIPTION
This commit introduces a dark mode toggle feature, enhancing user experience by allowing users to switch between light and dark themes.

*   Adds a top bar.
*   The changes include adding a toggle button to the top bar of the page.
*   It also includes a script to handle the toggle functionality and persist the user's theme preference using local storage.
*   CSS variables are used to define color schemes for both light and dark modes, ensuring a visually consistent experience.